### PR TITLE
Add newline to prevent error during `rig project setup`

### DIFF
--- a/generators/environment/templates/docker/build.yml
+++ b/generators/environment/templates/docker/build.yml
@@ -142,7 +142,8 @@ services:
       # within the build container.
       # See: https://github.com/paulmillr/chokidar/blob/master/README.md#user-content-performance
       CHOKIDAR_USEPOLLING: 1
-      <% } -%># Set to "true" to load xdebug configuration. Note this will cause significant composer
+      <% } -%>
+      # Set to "true" to load xdebug configuration. Note this will cause significant composer
       # performance degradation.
       PHP_XDEBUG: "false"
       # Suppress the loading of grunt-drupal-tasks desktop notification functionality.


### PR DESCRIPTION
Without this, I get the following error during `rig project setup`:

```
Digest: sha256:b216d36a44018d61a0f349d8081d7979cd01e7599ca25604365fce8252d53fcc
Status: Downloaded newer image for outrigger/build:php56
sed: -e expression #1, char 214: unknown command: `\'
! WARNING: Version '6#' does not exist.
N/A: version "N/A -> N/A" is not yet installed.

You need to run "nvm install N/A" to install it before using it.
bash: npm: command not found
[ERROR] start.sh: Error: Line 134: docker-compose
Stopping mp7_local_cache ... done
Stopping mp7_local_db ... done
FAIL

start.sh: aborted (33)
 [ERROR] Error running project script 'setup': 33
```