### PR TITLE
Adding double dash to all-stop template

### DIFF
--- a/generators/environment/templates/docker/build.devcloud.yml
+++ b/generators/environment/templates/docker/build.devcloud.yml
@@ -133,7 +133,7 @@ services:
       # within the build container.
       # See: https://github.com/paulmillr/chokidar/blob/master/README.md#user-content-performance
       CHOKIDAR_USEPOLLING: 1
-      <% } -%># Set to "true" to load xdebug configuration. Note this will cause significant composer
+      <% } -%> # Set to "true" to load xdebug configuration. Note this will cause significant composer
       # performance degradation.
       PHP_XDEBUG: "false"
       # Suppress the loading of grunt-drupal-tasks desktop notification functionality.

--- a/generators/environment/templates/outrigger/outrigger.yml
+++ b/generators/environment/templates/outrigger/outrigger.yml
@@ -75,7 +75,7 @@ scripts:
   all-stop:
     description: Halt all containers associated with this project.
     run:
-      - rig project run:ps -q | xargs docker stop
+      - rig project run:ps -- -q | xargs docker stop
 
   logs:
     alias: logs

--- a/generators/environment/templates/outrigger/outrigger.yml
+++ b/generators/environment/templates/outrigger/outrigger.yml
@@ -75,7 +75,7 @@ scripts:
   all-stop:
     description: Halt all containers associated with this project.
     run:
-      - rig project run:ps -- -q | xargs docker stop
+      - rig project run:ps -q | xargs docker stop
 
   logs:
     alias: logs


### PR DESCRIPTION
I only tested this on a mac.  But the all-stop needed the double dash to work.