### PR TITLE
Add line break before if statement

### DIFF
--- a/generators/environment/templates/docker/build.yml
+++ b/generators/environment/templates/docker/build.yml
@@ -137,7 +137,8 @@ services:
       APP_DOMAIN: <%= host.local %>
       GDT_DOMAIN: <%= host.local %>
       # Check https://hub.docker.com/r/phase2/devtools-build/ for other Node version options.
-      NODE_VERSION: 6<% if (usePLS) { %>
+      NODE_VERSION: 6
+      <% if (usePLS) { %>
       # Allow for pattern lab compilation need detection with reasonable performance from
       # within the build container.
       # See: https://github.com/paulmillr/chokidar/blob/master/README.md#user-content-performance


### PR DESCRIPTION
When the generator creates the build.yml file for a new project without Pattern Lab Starter (PLS), the comment following the if statement gets pulled onto the same line as the node version. Adding a line break should fix this.