### PR TITLE
Add display errors configuration by default

### DIFF
--- a/generators/environment/templates/drupal/settings.common.php
+++ b/generators/environment/templates/drupal/settings.common.php
@@ -11,9 +11,10 @@ ini_set('display_errors', 1);
 if (PHP_SAPI !== 'cli') {
   ini_set('html_errors', 1);
 }
+<% if (drupalDistroVersion == '7.x') { %>
 // Forcibly disable poorman's cron.
 $conf['cron_safe_threshold'] = 0;
-
+<% } %>
 // Database connection settings.
 $databases['default']['default'] = array (
   'database' => '<%= machineName %>_drupal',

--- a/generators/environment/templates/drupal/settings.common.php
+++ b/generators/environment/templates/drupal/settings.common.php
@@ -1,6 +1,9 @@
 <?php
 /**
- * Additional site settings.
+ * Common site settings.
+ *
+ * The process of running 'grunt install' will automatically set up a Drupal
+ * sites/default/settings.php which includes this file.
  */
 
 // Forcibly disable poorman's cron.

--- a/generators/environment/templates/drupal/settings.common.php
+++ b/generators/environment/templates/drupal/settings.common.php
@@ -6,6 +6,11 @@
  * sites/default/settings.php which includes this file.
  */
 
+// Show errors including XDEBUG trace.
+ini_set('display_errors', 1);
+if (PHP_SAPI !== 'cli') {
+  ini_set('html_errors', 1);
+}
 // Forcibly disable poorman's cron.
 $conf['cron_safe_threshold'] = 0;
 


### PR DESCRIPTION
I have found many people do not think to turn this on for projects, but it seems like a sensible default.

Secondarily this PR removes poormanscron configuration for Drupal 8 builds.

#20 stipulates to attempt to only apply this in "development environments", going to leave that issue open for now to explore this as part of rearranging the configuration to make space for separate hosting config.