### PR TITLE
--unsafe-perm is now set by environment variable on build image.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -139,8 +139,8 @@ module.exports = Generator.extend({
       var gadgetOptions = {}
       if (options['usePLS']) {
         gadgetOptions.themeScripts = {
-          "compile-theme": "npm run setup --unsafe-perm && npm run compile --unsafe-perm",
-          "validate": "npm run test --unsafe-perm"
+          "compile-theme": "npm run setup && npm run compile",
+          "validate": "npm run test"
         };
       }
       this.composeWith(require.resolve('generator-gadget'), _.assign(options, gadgetOptions));

--- a/generators/environment/templates/bin/start.sh
+++ b/generators/environment/templates/bin/start.sh
@@ -128,10 +128,9 @@ cmd "docker-compose -f docker-compose.yml up -d <% if(cache.external) { %>cache 
 
 # Install dependencies and run main application build.
 # Run grunt with --force to ignore errors. This won't help if the errors bail the build.
-# --unsafe-perm ensures dispatch to theme-related operations can still run as root for Docker.
 echoInfo "When grunt commands fail they suggest running with '--force'.\n"
 echoInfo "This just suppresses errors and is unlikely to fix issues causing your build process to fail.\n"
-cmd "docker-compose run --rm -e NPM_CONFIG_LOGLEVEL=error cli \"npm install --unsafe-perm && grunt --timer --quiet ${NO_VALIDATE}\""
+cmd "docker-compose run --rm -e NPM_CONFIG_LOGLEVEL=error cli \"npm install && grunt --timer --quiet ${NO_VALIDATE}\""
 
 # Now safe to activate web container to support end-to-end testing.
 cmd "docker-compose -f docker-compose.yml up -d <% if(proxy.exists) { %>proxy <% } %>www"


### PR DESCRIPTION
Since https://github.com/phase2/docker-build/pull/33 has been merged, projects no longer need to use --unsafe-perm as a CLI flag.