### PR TITLE
Changes to pre-install.sh and start.sh

### DIFF
--- a/generators/environment/templates/bin/pre-install.sh
+++ b/generators/environment/templates/bin/pre-install.sh
@@ -10,6 +10,11 @@
 # of `grunt install`.
 ##
 
+if [ ! -f src/sites/default/default.settings.php ]; then
+  echo "There was an error building the docroot. Please run pre-install after it has been successfully built."
+  exit 1
+fi
+
 <% if (cache.service == 'memcache') { %># Ensure Memcache does not hold onto stale data in between site installation runs.
 echo "Flush Memcache with 'flush_all'"
 echo "flush_all" | nc cache 11211

--- a/generators/environment/templates/bin/pre-install.sh
+++ b/generators/environment/templates/bin/pre-install.sh
@@ -11,7 +11,7 @@
 ##
 
 if [ ! -f src/sites/default/default.settings.php ]; then
-  echo "There was an error building the docroot. Please run pre-install after it has been successfully built."
+  echo "Please run pre-install after successfully building the docroot."
   exit 1
 fi
 

--- a/generators/environment/templates/bin/pre-install.sh
+++ b/generators/environment/templates/bin/pre-install.sh
@@ -10,11 +10,6 @@
 # of `grunt install`.
 ##
 
-if [ ! -f src/sites/default/default.settings.php ]; then
-  echo "Please run pre-install after successfully building the docroot."
-  exit 1
-fi
-
 <% if (cache.service == 'memcache') { %># Ensure Memcache does not hold onto stale data in between site installation runs.
 echo "Flush Memcache with 'flush_all'"
 echo "flush_all" | nc cache 11211

--- a/generators/environment/templates/bin/start.sh
+++ b/generators/environment/templates/bin/start.sh
@@ -144,7 +144,7 @@ cmd "docker exec <%= machineName %>_${DOCKER_ENV}_www \"/var/www/bin/fix-perms.s
 # Install the site.
 if [ "$UPDATE" == 0 ]; then
   if [ ! -z "$FORCE" ]; then
-    echoInfo "The start.sh --force flag was used, site install will proceed despite any errors."
+    echoInfo "The start.sh --force flag was used, site install will proceed despite any errors.\n"
   fi
   cmd "docker-compose run --rm grunt \"install --no-db-load${FORCE}\""
 else

--- a/generators/environment/templates/bin/start.sh
+++ b/generators/environment/templates/bin/start.sh
@@ -140,12 +140,10 @@ cmd "docker exec <%= machineName %>_${DOCKER_ENV}_www \"/var/www/bin/fix-perms.s
 
 # Install the site.
 if [ "$UPDATE" == 0 ]; then
-  # Errors in final steps of installation require --force to ensure bin/post-install.sh is run.
-  # Dev triggers a development build of Open Atrium
-  cmd "docker-compose run --rm cli \"grunt install --no-db-load --force\""
+  cmd "docker-compose run --rm grunt \"install --no-db-load\""
 else
   echoInfo "'grunt update' is defined in Gruntconfig.json\n"
-  cmd "docker-compose run --rm cli grunt update"
+  cmd "docker-compose run --rm grunt update"
 fi
 
 # Wipe cache after permissions fix.

--- a/generators/environment/templates/bin/start.sh
+++ b/generators/environment/templates/bin/start.sh
@@ -15,6 +15,7 @@ source "$CALLPATH/framework.sh"
 
 NAME=`basename "$0"`
 NO_VALIDATE=''
+FORCE=''
 NOOP=0
 # This version is used to facilitate troubleshooting, by indicating which
 # version of the generator-outrigger-drupal project produced this script.
@@ -54,6 +55,7 @@ while true ; do
     dev|int|local|ms|qa|review) DOCKER_ENV=$1 ; shift ;;
     -e|--environment) DOCKER_ENV=$2 ; shift 2 ;;
     -i|--no-validate) NO_VALIDATE=" --no-validate"; shift ;;
+    -f|--force) FORCE=" --force"; shift ;;
     -u|--update) UPDATE=1; shift ;;
     -n|--noop) export NOOP=1; shift ;;
     *) shift ; break ;;
@@ -140,7 +142,7 @@ cmd "docker exec <%= machineName %>_${DOCKER_ENV}_www \"/var/www/bin/fix-perms.s
 
 # Install the site.
 if [ "$UPDATE" == 0 ]; then
-  cmd "docker-compose run --rm grunt \"install --no-db-load\""
+  cmd "docker-compose run --rm grunt \"install --no-db-load ${FORCE}\""
 else
   echoInfo "'grunt update' is defined in Gruntconfig.json\n"
   cmd "docker-compose run --rm grunt update"

--- a/generators/environment/templates/bin/start.sh
+++ b/generators/environment/templates/bin/start.sh
@@ -41,6 +41,7 @@ Usage: $name [options]
 -i|--no-validate     Skip the static analysis validate step.
                      Useful for speedy build process, or when the report-generating
                      analyze task will also be used.
+-f|--force           Force grunt install to complete regardless of errors.
 -n|--noop            Take no action, just output the commands to be run.
 -u|--update          Instead of site install, run site update procedures.
 EOF
@@ -132,7 +133,7 @@ cmd "docker-compose -f docker-compose.yml up -d <% if(cache.external) { %>cache 
 # Run grunt with --force to ignore errors. This won't help if the errors bail the build.
 echoInfo "When grunt commands fail they suggest running with '--force'.\n"
 echoInfo "This just suppresses errors and is unlikely to fix issues causing your build process to fail.\n"
-cmd "docker-compose run --rm -e NPM_CONFIG_LOGLEVEL=error cli \"npm install && grunt --timer --quiet ${NO_VALIDATE}\""
+cmd "docker-compose run --rm -e NPM_CONFIG_LOGLEVEL=error cli \"npm install && grunt --timer --quiet${NO_VALIDATE}\""
 
 # Now safe to activate web container to support end-to-end testing.
 cmd "docker-compose -f docker-compose.yml up -d <% if(proxy.exists) { %>proxy <% } %>www"
@@ -142,7 +143,10 @@ cmd "docker exec <%= machineName %>_${DOCKER_ENV}_www \"/var/www/bin/fix-perms.s
 
 # Install the site.
 if [ "$UPDATE" == 0 ]; then
-  cmd "docker-compose run --rm grunt \"install --no-db-load ${FORCE}\""
+  if [ ! -z "$FORCE" ]; then
+    echoInfo "The start.sh --force flag was used, site install will proceed despite any errors."
+  fi
+  cmd "docker-compose run --rm grunt \"install --no-db-load${FORCE}\""
 else
   echoInfo "'grunt update' is defined in Gruntconfig.json\n"
   cmd "docker-compose run --rm grunt update"


### PR DESCRIPTION
* Removes --force from grunt install in start.sh.
* Calls grunt in start.sh without using cli.
* Add the ability to `--force` install with a flag for start.sh