### PR TITLE
Fix cli command to actually use bash

### DIFF
--- a/generators/environment/templates/docker/build.devcloud.yml
+++ b/generators/environment/templates/docker/build.devcloud.yml
@@ -27,6 +27,7 @@ services:
   cli:
     extends:
       service: operational
+    command: /bin/bash
 
   # Container for running composer in the repo root.
   # Usage: DOCKER_ENV=int docker-compose -f build.devcloud.yml -p <%= machineName %>_int run --rm composer <command>


### PR DESCRIPTION
Running "docker-compose -f build.devcloud.yml run -rm cli" doesn't actually run bash. The line I added is in the normal build.yml but not in build.devcloud.yml for some reason.