### PR TITLE
Explicit entry of ci host for new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v4.0.0-pre (August 42, 2020)
+
+### Upgrade Instructions
+
+To continue using the --replay flag with projects generated before v4, please make the following changes to your `.yo-rc.json` file, hidden at the root of your git repo.
+* Replace `useEnv` with `useCloud`.
+* Add `cloudHost` key set to the URL of your Docker host. (`ci.p2devcloud.com` or `ci2.p2devcloud.com`)
+
 ## v3.4.0 (July 18, 2017)
 
 * Added display_errors by default in Drupal settings.common.php.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -130,6 +130,11 @@ module.exports = Generator.extend({
       delete store['resolved'];
       this.config.set(store);
 
+    }.bind(this));
+  },
+
+  configuring: {
+    sensibleDefaults: function() {
       options['skip-readme'] = true;
       // If using Docker-based environment defer running install locally.
       if (options['useENV']) {
@@ -145,7 +150,7 @@ module.exports = Generator.extend({
         // generator can set up theme wiring. This is the hard-coded name.
         options['themeName'] = 'patternlab';
       }
-    }.bind(this));
+    }
   },
 
   writing: {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -209,6 +209,9 @@ module.exports = Generator.extend({
     if (options['useCloud']) {
       this.log('Your project is setup to have project testing environments created via Outrigger Cloud by ' + chalk.red('generator-outrigger-drupal:cloud v' + version.env) + '.');
     }
+    else {
+      this.log('Your project is ' + chalk.yellow('not configured to use Outrigger Dev Cloud,') + ' to use this later you can re-run the generator.');
+    }
     if (options['usePLS']) {
       this.log('You have created a new theme ' + chalk.green(options.themeName) + ' at ' + chalk.red(options.themePath) + ' with ' + chalk.red('generator-pattern-lab-starter v' + version.pls) + '.');
     }

--- a/generators/cloud/prompts.js
+++ b/generators/cloud/prompts.js
@@ -1,4 +1,21 @@
+var url = require('url');
+
 var prompts = [
+  {
+    type: 'input',
+    name: 'cloudHost',
+    message: 'Outrigger Cloud base URL for your project (Ask for this!): ',
+    validate: function (input) {
+      if (!input) return 'You must specify a valid domain such as "ci.p2devcloud.com". If you do not have this information, abort and retry answering "No" to Cloud Hosting.';
+      if (input.search(' ') !== -1) return 'No spaces allowed.';
+      if (input.search('_') !== -1) return 'No underscores allowed.';
+      return true;
+    },
+    filter: function (input) {
+      parsed = url.parse(input);
+      return parsed.host || parsed.href;
+    }
+  },
   {
     type: 'checkbox',
     name: 'environments',

--- a/generators/cloud/templates/DEVCLOUD.md
+++ b/generators/cloud/templates/DEVCLOUD.md
@@ -6,8 +6,7 @@ Outrigger Hosting is Phase2's docker-based hosting platform for our development 
 
 ## Server Location
 
-All Docker-based hosted sites are located on ci.p2devcloud.com or
-ci2.p2devcloud.com.
+These Docker-based hosted sites are on servers managed by the Phase2 Infrastructure Team.
 
 You can reach an environment on the server via:
 

--- a/generators/environment/templates/docs/TODOS.md
+++ b/generators/environment/templates/docs/TODOS.md
@@ -28,10 +28,10 @@ complete. As items are accomplished, they can be removed from this file.
     * Modify scripts to suite your needs, or remove scripts you will not use and maintain as it will simply be clutter.
     * Rewrite codebase documentation to suite the audience. Make sure future onboarding will work.
 
-* [ ] Spin up Continuous Integration & Testing Environments: This is specific to Phase2-only infrastructure at this time.
+<% if (useCloud.exists) { %>* [ ] Spin up Continuous Integration & Testing Environments: This is specific to Phase2-only infrastructure at this time.
     * Ensure the Jenkins jobs have the correct Git URL. (You can correct this by editing .yo-rc.json and running the generator again with `--replay`.)
     * Visit your CI Server and [spin up your Jenkins instance](http://build.<%= host.devcloud %>/job/ci-start/parambuild/?delay=0sec&NAME=<%= projectName %>&GIT_URL=git%40bitbucket.org%3Aphase2tech%2F<%= projectName %>.git&GIT_REF=develop).
-
+<% } %>
 <% if (mail.exists) { %>* [ ] Configure Email Testing: Add the SMTP module to the project to use MailHog for testing.
     * Add the SMTP module to the codebase.
     * Enable the module and turn on STMP mail transport at `admin/config/system/smtp`.

--- a/generators/lib/env.js
+++ b/generators/lib/env.js
@@ -7,17 +7,7 @@ module.exports = function(options) {
   var host;
 
   function ciHost() {
-    if (!host) {
-      host = options['ciHost'];
-      if (!options['ciHost']) {
-        var host = 'ci.p2devcloud.com';
-        if (Math.random() <= 0.5) {
-          host = 'ci2.p2devcloud.com'
-        }
-      }
-    }
-
-    return host;
+    return options['cloudHost'];
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-outrigger-drupal",
-  "version": "3.5.0-pre",
+  "version": "4.0.0-pre",
   "description": "Yeoman Generator for Outrigger-based Drupal projects.",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
The Outrigger Dev Cloud is bursting at the seams. In preparation for adding more capacity and switching to "human-routed" hosting assignments, making the ci host selection explicit.

In practice, if someone doesn't answer the new prompt they will need to abort and retry without the cloud option activated. Hopefully they just pause and ask the infrastructure team and be assigned the right server.

We are still working on the automatically scaling solution which will allow us to remove some of the phase2-isms here, as well as remove the need for this kind of hosting micro-management.